### PR TITLE
Fix findbar not expanding

### DIFF
--- a/chrome/resources/userChrome.ag.css
+++ b/chrome/resources/userChrome.ag.css
@@ -16,3 +16,7 @@ tooltip {
 	border-image: 1 1 1 1 linear-gradient(to right, #9f1aff, #9f1aff, #8a46ff, #765dff, #5d7dff, #3e8cff, #1c99ff, #00a5ff, #00b4ff, #00c3ff, #00d0ff, #00ddff) !important;
   
   }
+
+findbar > .findbar-container {
+    flex: none !important;
+  }


### PR DESCRIPTION
The findbar did not stretch completely thus hiding certain options.
This was not an issue for most English users with average 1920x1080 monitors because the words are smaller.

Tested on the latest Firefox stable in English and Portuguese interface languages.

The code had to go in `resources/userChrome.ag.css` because the `flex` attribute could not be overridden without fx-autoconfig.